### PR TITLE
Support android content resolver uri

### DIFF
--- a/android/src/main/java/com/rumax/reactnative/pdfviewer/AsyncDownload.java
+++ b/android/src/main/java/com/rumax/reactnative/pdfviewer/AsyncDownload.java
@@ -6,6 +6,8 @@ package com.rumax.reactnative.pdfviewer;
  * This source code is licensed under the MIT license
  */
 
+import android.content.Context;
+import android.net.Uri;
 import android.os.AsyncTask;
 
 import com.facebook.react.bridge.ReadableMap;
@@ -24,17 +26,20 @@ import java.net.URL;
 class AsyncDownload extends AsyncTask<Void, Void, Void> {
     public static final String HTTP = "http";
     public static final String HTTPS = "https";
+    public static final String CONTENT = "content";
     private static final int BUFF_SIZE = 8192;
     private static final String PROP_METHOD = "method";
     private static final String PROP_BODY = "body";
     private static final String PROP_HEADERS = "headers";
+    private Context context;
     private final ReadableMap urlProps;
     private TaskCompleted listener;
     private File file;
     private String url;
     private Exception exception;
 
-    AsyncDownload(String url, File file, ReadableMap urlProps, TaskCompleted listener) {
+    AsyncDownload(Context context, String url, File file, ReadableMap urlProps, TaskCompleted listener) {
+        this.context = context;
         this.listener = listener;
         this.file = file;
         this.url = url;
@@ -47,28 +52,27 @@ class AsyncDownload extends AsyncTask<Void, Void, Void> {
         exception = null;
     }
 
-    @Override
-    protected Void doInBackground(Void... params) {
-        URL url;
-        HttpURLConnection connection;
-
-        try {
-            url = new URL(this.url);
-            String protocol = url.getProtocol();
-            if (!protocol.equalsIgnoreCase(HTTP) && !protocol.equalsIgnoreCase(HTTPS)) {
-                exception = new IOException("Protocol \"" + protocol + "\" is not supported");
-                return null;
-            }
-            connection = (HttpURLConnection) url.openConnection();
-            enrichWithUrlProps(connection);
-            connection.connect();
-        } catch (Exception e) {
-            exception = e;
-            return null;
+    private InputStream getInputStream() throws IOException {
+        Uri uri = Uri.parse(this.url);
+        if (uri.getScheme().equalsIgnoreCase(CONTENT)) {
+            return context.getContentResolver().openInputStream(uri);
         }
 
+        URL url = new URL(this.url);
+        String protocol = url.getProtocol();
+        if (!protocol.equalsIgnoreCase(HTTP) && !protocol.equalsIgnoreCase(HTTPS)) {
+            throw new IOException("Protocol \"" + protocol + "\" is not supported");
+        }
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        enrichWithUrlProps(connection);
+        connection.connect();
+        return new BufferedInputStream(connection.getInputStream(), BUFF_SIZE);
+    }
+
+    @Override
+    protected Void doInBackground(Void... params) {
         try (
-                InputStream input = new BufferedInputStream(connection.getInputStream(), BUFF_SIZE);
+                InputStream input = getInputStream();
                 OutputStream output = new FileOutputStream(file)
         ) {
             int count;

--- a/android/src/main/java/com/rumax/reactnative/pdfviewer/PDFView.java
+++ b/android/src/main/java/com/rumax/reactnative/pdfviewer/PDFView.java
@@ -160,7 +160,7 @@ public class PDFView extends com.github.barteksc.pdfviewer.PDFView implements
             return;
         }
 
-        downloadTask = new AsyncDownload(resource, downloadedFile, urlProps, new AsyncDownload.TaskCompleted() {
+        downloadTask = new AsyncDownload(context, resource, downloadedFile, urlProps, new AsyncDownload.TaskCompleted() {
             @Override
             public void onComplete(Exception ex) {
                 if (ex == null) {


### PR DESCRIPTION
### Description of changes

Similar to https://github.com/songsterq/react-native-PDFView/pull/1, I want to be able to view the PDF file picked by `Intent.ACTION_GET_CONTENT` on Android. (I am trying to make this work nicely with https://www.npmjs.com/package/react-native-document-picker on both platforms.)

In that case I get back an `Uri` that needs to be opened using the content resolver. I thought about whether to fit this into `renderFromUrl` or `renderFromFile`. I decided on `renderFromUrl` because the intent can return a local file as well as a file stored in google drive that's not downloaded yet, in that case trying to get a `FileInputStream` may not work.

### I did Exploratory testing:
- [x] android
- [ ] ios

### Can it be published to NPM?
- [ ] Breaking change
- [ ] Documentation is updated