### PR TITLE
Throw error on iOS webview provisonal navigation failure

### DIFF
--- a/ReactNativeViewPDF/RNPDFView.m
+++ b/ReactNativeViewPDF/RNPDFView.m
@@ -202,6 +202,10 @@
     [self throwError: ERROR_ONLOADING withMessage: error.localizedDescription];
 }
 
+- (void)webView:(WKWebView *)webView didFailProvisionalNavigation:(WKNavigation *)navigation withError:(NSError *)error {
+    [self throwError: ERROR_ONLOADING withMessage: error.localizedDescription];
+}
+
 - (NSURL *)fileFromBundleURL {
     NSString *resourcePath = [_resource stringByReplacingOccurrencesOfString: @".pdf" withString: @""]; // Remove pdf extension from path if present
     if (![[NSBundle mainBundle] pathForResource: resourcePath ofType: @"pdf"]) {


### PR DESCRIPTION
### Description of changes

Adding `webView:didFailProvisionalNavigation:withError:` to the delegate to so I can get an error callback when timeout occurs.

### I did Exploratory testing:
- [ ] android
- [x] ios

### Can it be published to NPM?
- [ ] Breaking change
- [ ] Documentation is updated
